### PR TITLE
fix: add missing exec and enum value

### DIFF
--- a/src/LeakyBucket.ts
+++ b/src/LeakyBucket.ts
@@ -76,8 +76,11 @@ export const makeDrainBucket = (
           if (newVal < 0) {
             await redis
               .multi()
-              .del(`${bucketTypeName}:${bucketName}:${LeakyBucketSpecialKeys}`)
-              .srem(bucketTypeName, bucketName);
+              .del(
+                `${bucketTypeName}:${bucketName}:${LeakyBucketSpecialKeys.BucketCurrentCapacity}`,
+              )
+              .srem(bucketTypeName, bucketName)
+              .exec();
           }
         }
       }),


### PR DESCRIPTION
# Description

This adds a missing `exec()` call for `multi()` pipeline. It also fixes a Redis key.

# Motivation and Context

Closes #3.
Closes #4.