### PR TITLE
docs: fix global bucket example name

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Now, you can do:
 ```typescript
 await worker.addJob('send-message', payload, {
   flags: [
-    'send-message-global',
+    'send-message-global:global',
     'send-message-client:b412d632-e004-11ea-87d0-0242ac130003',
     'send-message-phone:+12025550320',
   ],
@@ -64,7 +64,7 @@ perform graphile_worker.add_job(
   'send-message',
   payload,
   flags => ARRAY[
-    'send-message-global',
+    'send-message-global:global',
     'send-message-client:b412d632-e004-11ea-87d0-0242ac130003',
     'send-message-phone:+12025550320'
   ]


### PR DESCRIPTION
# Description

This updates the example in the documentation to correctly demonstrate use of a global queue.

# Motivation and Context.

Bucket names _must_ consist of a type (e.g. `send-message-phone `) and a specific bucket name (e.g. `+12025550320`). This goes for  a global queue as well.

Closes #5.